### PR TITLE
Fixed Spawn Eggs

### DIFF
--- a/src/main/java/uwu/lopyluna/create_dd/registry/DesiresEntityTypes.java
+++ b/src/main/java/uwu/lopyluna/create_dd/registry/DesiresEntityTypes.java
@@ -1,5 +1,6 @@
 package uwu.lopyluna.create_dd.registry;
 
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
 import com.simibubi.create.foundation.data.CreateEntityBuilder;
 import com.tterrag.registrate.util.entry.EntityEntry;
@@ -29,7 +30,7 @@ import uwu.lopyluna.create_dd.DesiresCreate;
 
 import static uwu.lopyluna.create_dd.DesiresCreate.REGISTRATE;
 
-@SuppressWarnings({"unused", "all"})
+@SuppressWarnings({"unused","all"})
 public class DesiresEntityTypes {
 
 	public static final EntityEntry<SeethingBlaze> SEETHING_ABLAZE = REGISTRATE.entity("seething_ablaze", SeethingBlaze::new, MobCategory.MONSTER)
@@ -48,6 +49,9 @@ public class DesiresEntityTypes {
 					.clientTrackingRange(8))
 			.renderer(() -> SeethingBlazeRenderer::new)
 			.attributes(SeethingBlaze::createAttributes)
+			.spawnEgg(0x2677B5, 0x54479E)
+						.tag(AllTags.AllItemTags.BLAZE_BURNER_FUEL_SPECIAL.tag)
+			.build()
 			.register();
 
 	public static final EntityEntry<InertBlaze> INERT_BLAZELING = REGISTRATE.entity("inert_blazeling", InertBlaze::new, MobCategory.CREATURE)
@@ -65,6 +69,7 @@ public class DesiresEntityTypes {
 					.sized(0.6F, 0.75F)
 					.clientTrackingRange(4))
 			.attributes(InertBlaze::createAttributes)
+			.spawnEgg(0x804424,0x8B7A3D ).build()
 			.register();
 
 

--- a/src/main/java/uwu/lopyluna/create_dd/registry/DesiresItems.java
+++ b/src/main/java/uwu/lopyluna/create_dd/registry/DesiresItems.java
@@ -301,19 +301,6 @@ public class DesiresItems {
 			.lang("Music Disc")
 			.register();
 
-	//public static final ItemEntry<SpawnEggItem> INERT_BLAZELING_SPAWN_EGG = REGISTRATE.item("inert_blazeling_spawn_egg",
-	//				p -> new SpawnEggItem(DesiresEntityTypes.INERT_BLAZELING.get(), 5451574, 13661252, p))
-	//		.model((c, p) -> p.withExistingParent(c.getId().getPath(),
-	//				new ResourceLocation("item/template_spawn_egg")))
-	//		.register();
-
-	//public static final ItemEntry<SpawnEggItem> SEETHING_ABLAZE_SPAWN_EGG = REGISTRATE.item("seething_ablaze_spawn_egg",
-	//				p -> new SpawnEggItem(DesiresEntityTypes.SEETHING_ABLAZE.get(), 44543, 56063, p))
-	//		.tag(AllTags.AllItemTags.BLAZE_BURNER_FUEL_SPECIAL.tag)
-	//		.model((c, p) -> p.withExistingParent(c.getId().getPath(),
-	//				new ResourceLocation("item/template_spawn_egg")))
-	//		.register();
-
 	public static final ItemEntry<CombustibleItem> SEETHING_ABLAZE_ROD = REGISTRATE.item("seething_ablaze_rod", CombustibleItem::new)
 			.tag(AllTags.AllItemTags.BLAZE_BURNER_FUEL_SPECIAL.tag)
 			.onRegister(i -> i.setBurnTime(9600))


### PR DESCRIPTION
Spawn eggs were being registered before the mobs were. Although the method used is deprecated, it gets the job done. There was no documentation stating which way or method was preferred, though.