### PR TITLE
fix: Smart Hopper should not consume items from source when full

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/smart_hopper/SmartHopperBE.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/smart_hopper/SmartHopperBE.java
@@ -129,7 +129,7 @@ public class SmartHopperBE extends SmartBlockEntity implements MenuProvider {
     }
 
     protected boolean cantAcceptItem(ItemStack stack, BlockState state) {
-        return ItemHandlerHelper.insertItem(inv, stack.copy(), true) == stack || cantActivate(state) || !filtering.test(stack);
+        return ItemHandlerHelper.insertItem(inv, stack.copy(), true).getCount() == stack.getCount() || cantActivate(state) || !filtering.test(stack);
     }
 
     protected boolean cantActivate(BlockState state) {


### PR DESCRIPTION
Hii

Just a small fix.
cantAcceptItem is passing a copy of the stack to the ItemHandlerHelper.insertItem call so this equality was always false, that was causing the hopper to drain items from source even when it had nowhere to go. I thought maybe checking for the count would be safer? 🤷‍♀️ 



https://github.com/user-attachments/assets/c63fc856-41bc-48f7-b514-7ce651619b3d


