### PR TITLE
Fix Server Crash when Gold Mixer Spins in the wrong direction

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/content/blocks/kinetics/golden_mixer/GoldenMixerBE.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/blocks/kinetics/golden_mixer/GoldenMixerBE.java
@@ -140,7 +140,7 @@ public class GoldenMixerBE extends BasinOperatingBlockEntity {
                     var basin = getBasin();
                     if (basin.isPresent()) {
                         var tanks = basin.get().getTanks();
-                        if ((!tanks.getFirst().isEmpty() || !tanks.getSecond().isEmpty()) && level.random.nextInt((int) speedSpeed) <= 32)
+                        if ((!tanks.getFirst().isEmpty() || !tanks.getSecond().isEmpty()) && level.random.nextInt(Math.abs((int) speedSpeed)) <= 32)
                             level.playSound(null, worldPosition, SoundEvents.BUBBLE_COLUMN_WHIRLPOOL_AMBIENT, SoundSource.BLOCKS, .75f, speed < 65 ? .75f : 1.5f);
                     }
                 } else {


### PR DESCRIPTION
```
---- Minecraft Crash Report ----
// I just don't know what went wrong :(

Time: 2025-09-22 14:52:19
Description: Ticking block entity

java.lang.IllegalArgumentException: Bound must be positive
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.levelgen.BitRandomSource.nextInt(BitRandomSource.java:22) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:classloading,re:mixin}
	at TRANSFORMER/dndesires@2.2c-BETA/dev.lopyluna.dndesires.content.blocks.kinetics.golden_mixer.GoldenMixerBE.tick(GoldenMixerBE.java:143) ~[DnDesires-1.21.1-2.2c-BETA.jar%23249!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/create@6.0.6/com.simibubi.create.foundation.blockEntity.SmartBlockEntityTicker.tick(SmartBlockEntityTicker.java:15) ~[create-1.21.1-6.0.6.jar%23223!/:6.0.6] {re:classloading}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.tick(LevelChunk.java:711) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,re:classloading,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.world.block_entity_ticking.support_cache.DirectBlockEntityTickInvokerMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.world_border.DirectBlockEntityTickInvokerMixin from mod lithium,pl:mixin:APP:polymorph.mixins.json:MixinLevelChunk from mod polymorph,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.tick(LevelChunk.java:788) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,re:classloading,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.WrappedBlockEntityTickInvokerAccessor from mod lithium,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.tickBlockEntities(Level.java:565) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:sliceanddice.mixins.json:LevelMixin from mod sliceanddice,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.collisions.empty_space.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.LevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.data_storage.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.chunk_tickable.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.chunk_access.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.LevelMixin from mod lithium,pl:mixin:APP:lithium-neoforge.mixins.json:block.hopper.LevelMixin from mod lithium,pl:mixin:APP:c2me-fixes-worldgen-threading-issues.mixins.json:threading_detections.random_instances.MixinWorld from mod c2me_fixes_worldgen_threading_issues,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinWorld from mod c2me_opts_scheduling,pl:mixin:APP:c2me-notickvd.mixins.json:MixinWorld from mod c2me_notickvd,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:428) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:libx:level_load,re:classloading,pl:accesstransformer:B,xf:fml:libx:level_load,pl:mixin:APP:supplementaries-common.mixins.json:ServerLevelMixin from mod supplementaries,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.spawning.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.ServerLevelMixin from mod lithium,pl:mixin:APP:moonlight-common.mixins.json:ServerLevelMixin from mod moonlight,pl:mixin:APP:polymorph.mixins.json:MixinServerLevel from mod polymorph,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor from mod create,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinServerWorld from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:shutdown.MixinServerWorld from mod c2me_opts_scheduling,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1037) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:APP:c2me-fixes-general-threading-issues.mixins.json:asynccatchers.MixinMinecraftServer from mod c2me_fixes_general_threading_issues,pl:mixin:APP:c2me-rewrites-chunk-system.mixins.json:MixinMinecraftServer from mod c2me_rewrites_chunk_system,pl:mixin:APP:c2me-opts-scheduling.mixins.json:idle_tasks.autosave.enhanced_autosave.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:shutdown.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-notickvd.mixins.json:MixinMinecraftServer from mod c2me_notickvd,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:317) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,re:classloading,pl:mixin:APP:lithostitched.mixins.json:server.DedicatedServerMixin from mod lithostitched,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:917) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:APP:c2me-fixes-general-threading-issues.mixins.json:asynccatchers.MixinMinecraftServer from mod c2me_fixes_general_threading_issues,pl:mixin:APP:c2me-rewrites-chunk-system.mixins.json:MixinMinecraftServer from mod c2me_rewrites_chunk_system,pl:mixin:APP:c2me-opts-scheduling.mixins.json:idle_tasks.autosave.enhanced_autosave.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:shutdown.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-notickvd.mixins.json:MixinMinecraftServer from mod c2me_notickvd,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:707) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:APP:c2me-fixes-general-threading-issues.mixins.json:asynccatchers.MixinMinecraftServer from mod c2me_fixes_general_threading_issues,pl:mixin:APP:c2me-rewrites-chunk-system.mixins.json:MixinMinecraftServer from mod c2me_rewrites_chunk_system,pl:mixin:APP:c2me-opts-scheduling.mixins.json:idle_tasks.autosave.enhanced_autosave.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:shutdown.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-notickvd.mixins.json:MixinMinecraftServer from mod c2me_notickvd,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267) ~[server-1.21.1-20240808.144430-srg.jar%23207!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:APP:c2me-fixes-general-threading-issues.mixins.json:asynccatchers.MixinMinecraftServer from mod c2me_fixes_general_threading_issues,pl:mixin:APP:c2me-rewrites-chunk-system.mixins.json:MixinMinecraftServer from mod c2me_rewrites_chunk_system,pl:mixin:APP:c2me-opts-scheduling.mixins.json:idle_tasks.autosave.enhanced_autosave.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:mid_tick_chunk_tasks.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-opts-scheduling.mixins.json:shutdown.MixinMinecraftServer from mod c2me_opts_scheduling,pl:mixin:APP:c2me-notickvd.mixins.json:MixinMinecraftServer from mod c2me_notickvd,pl:mixin:A}
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?] {re:mixin}
```