### PR TITLE
Fix save bricking crash

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/content/blocks/kinetics/golden_mixer/GoldenMixerBE.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/blocks/kinetics/golden_mixer/GoldenMixerBE.java
@@ -140,8 +140,10 @@ public class GoldenMixerBE extends BasinOperatingBlockEntity {
                     var basin = getBasin();
                     if (basin.isPresent()) {
                         var tanks = basin.get().getTanks();
-                        if ((!tanks.getFirst().isEmpty() || !tanks.getSecond().isEmpty()) && level.random.nextInt(Math.abs((int) speedSpeed)) <= 32)
-                            level.playSound(null, worldPosition, SoundEvents.BUBBLE_COLUMN_WHIRLPOOL_AMBIENT, SoundSource.BLOCKS, .75f, speed < 65 ? .75f : 1.5f);
+                        if (speedSpeed != 0) {
+                            if ((!tanks.getFirst().isEmpty() || !tanks.getSecond().isEmpty()) && level.random.nextInt(Math.abs((int) speedSpeed)) <= 32)
+                                level.playSound(null, worldPosition, SoundEvents.BUBBLE_COLUMN_WHIRLPOOL_AMBIENT, SoundSource.BLOCKS, .75f, speed < 65 ? .75f : 1.5f);
+                        }
                     }
                 } else {
                     processingTicks--;


### PR DESCRIPTION
Added a check to prevent calling level.random.nextInt() with argument 0. 
Fixes a crash that effectively bricks the save as loading the chunk containing the block will instantly crash the game.