### PR TITLE
Update BoreBlock.java for better contraption collisions

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/bore_block/BoreBlock.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/bore_block/BoreBlock.java
@@ -8,23 +8,36 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import dev.ryanhcode.sable.api.block.BlockSubLevelCollisionShape;
 
 @SuppressWarnings("NullableProblems")
-public class BoreBlock extends Block {
+public class BoreBlock extends Block implements BlockSubLevelCollisionShape {
+    private static final VoxelShape worldCollision = Shapes.block();
+    private static final VoxelShape mountCollision = Block.box(7, 7, 7, 9, 9, 9);
+
     public BoreBlock(Properties properties) {
         super(properties);
     }
 
     @Override
     protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return context.equals(CollisionContext.empty()) ? Block.box(4, 4, 4, 12, 12, 12) : super.getShape(state, level, pos, context);
+        return worldCollision;
+    }
+
+    @Override
+    protected VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return worldCollision;
+    }
+
+    @Override
+    public VoxelShape getSubLevelCollisionShape(BlockGetter blockGetter, BlockState state) {
+        return mountCollision;
     }
 
     @Override
     protected VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return Shapes.block();
     }
-
 
     @Override
     protected boolean skipRendering(BlockState state, BlockState adjacentBlockState, Direction side) {

--- a/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/bore_block/BoreBlock.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/blocks/logistics/bore_block/BoreBlock.java
@@ -8,30 +8,16 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import dev.ryanhcode.sable.api.block.BlockSubLevelCollisionShape;
 
 @SuppressWarnings("NullableProblems")
-public class BoreBlock extends Block implements BlockSubLevelCollisionShape {
-    private static final VoxelShape worldCollision = Shapes.block();
-    private static final VoxelShape mountCollision = Block.box(7, 7, 7, 9, 9, 9);
-
+public class BoreBlock extends Block {
     public BoreBlock(Properties properties) {
         super(properties);
     }
 
     @Override
     protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return worldCollision;
-    }
-
-    @Override
-    protected VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return worldCollision;
-    }
-
-    @Override
-    public VoxelShape getSubLevelCollisionShape(BlockGetter blockGetter, BlockState state) {
-        return mountCollision;
+        return context.equals(CollisionContext.empty()) ? Block.box(4, 4, 4, 12, 12, 12) : super.getShape(state, level, pos, context);
     }
 
     @Override

--- a/src/main/java/dev/lopyluna/dndesires/mixins/compat/sable/BoreBlockMixin.java
+++ b/src/main/java/dev/lopyluna/dndesires/mixins/compat/sable/BoreBlockMixin.java
@@ -1,0 +1,30 @@
+package dev.lopyluna.dndesires.mixins.compat.sable;
+
+import dev.lopyluna.dndesires.content.blocks.logistics.bore_block.BoreBlock;
+import dev.ryanhcode.sable.api.block.BlockSubLevelCollisionShape;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+
+@SuppressWarnings("NullableProblems")
+@Mixin(BoreBlock.class)
+public abstract class BoreBlockMixin extends Block implements BlockSubLevelCollisionShape {
+    public BoreBlockMixin(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    protected VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return Shapes.block();
+    }
+
+    @Override
+    public VoxelShape getSubLevelCollisionShape(BlockGetter blockGetter, BlockState state) {
+        return Block.box(7, 7, 7, 9, 9, 9);
+    }
+}

--- a/src/main/resources/dndesires.mixins.json
+++ b/src/main/resources/dndesires.mixins.json
@@ -21,6 +21,7 @@
     "PotatoProjectileEntityAccessor",
     "ServerGamePacketListenerImplAccessor",
     "TreeAccessor",
+    "compat.sable.BoreBlockMixin",
     "compat.sable.FanSailBlockMixin",
     "compat.sable.IndustrialAirCurrentMixin",
     "compat.sable.IndustrialFanBEMixin",


### PR DESCRIPTION
Fixed Bore blocks to have full collision with players and entities but have reduced size hitboxes on moving contraptions to aid in block breaking and prevent issues with aeronautics contraptions being flung while mining with them